### PR TITLE
Add support for link (btn) annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Gemfile.lock
 pkg/*
 data/output.pdf
+.idea/

--- a/lib/prawn-fillform.rb
+++ b/lib/prawn-fillform.rb
@@ -271,7 +271,8 @@ module Prawn
           when :Tx
             page_fields << Text.new(dictionary)
           when :Btn
-            if deref(dictionary[:AP]).has_key? :D
+            ap = deref(dictionary[:AP])
+            if ap.present? && ap.has_key?(:D)
               page_fields << Checkbox.new(dictionary)
             else
               page_fields << Button.new(dictionary)

--- a/lib/prawn-fillform/version.rb
+++ b/lib/prawn-fillform/version.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 module Prawn
   module Fillform
-    VERSION = "0.0.23.0.zp"
+    VERSION = "0.1.0.zp"
   end
 end


### PR DESCRIPTION
## Overview

Links are often annotated in PDF's and appear in the internal PDF structure as a `Btn` node without an `AP` key-value hash pair. 

See below
![Screen Shot 2019-05-03 at 5 24 15 PM](https://user-images.githubusercontent.com/2081297/57174312-c7508680-6df1-11e9-896d-e9c4c13919e2.png)

This PR adds support for these link annotations which will resolve the following `FormGeneratorWorker` dead sidekiq jobs.

![Screen Shot 2019-05-03 at 10 18 16 PM](https://user-images.githubusercontent.com/2081297/57174326-f109ad80-6df1-11e9-803f-e070487128bb.png)
![Screen Shot 2019-05-03 at 10 17 50 PM](https://user-images.githubusercontent.com/2081297/57174327-f109ad80-6df1-11e9-889f-1d02ecae0064.png)
