### PR TITLE
safely access kids key

### DIFF
--- a/lib/prawn-fillform.rb
+++ b/lib/prawn-fillform.rb
@@ -252,7 +252,7 @@ module Prawn
         # Support annotations with parents
         annots.flat_map do |ref|
           dictionary = deref(ref)
-          if dictionary[:Parent]
+          if dictionary[:Parent] && dictionary[:Parent][:Kids]
             deref(deref(dictionary[:Parent])[:Kids]).map { |kid| deref(kid) }.select { |kid| kid[:P] == page.dictionary }
           else
             [dictionary]

--- a/lib/prawn-fillform/version.rb
+++ b/lib/prawn-fillform/version.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 module Prawn
   module Fillform
-    VERSION = "0.1.0.zp"
+    VERSION = "0.1.1.zp"
   end
 end


### PR DESCRIPTION
Fixes https://app.bugsnag.com/gusto-3/zp-rails-payroll-payments-and-filings/errors/5cf199ae3ea3000019928689?filters[event.since][0]=30d&filters[error.status][0]=open

Stacktrace in Sidekiq Morgue shows worker was called with Form ID 7757842007200025:
![Screen Shot 2019-06-04 at 10 10 19 AM](https://user-images.githubusercontent.com/26313300/58895827-10764d80-86b2-11e9-95b5-2f91f11f1579.png)


Running Document::FormFiller.new.perform(7757842007200025) in production console produces this error:
<img width="1059" alt="Screen Shot 2019-06-04 at 10 09 21 AM" src="https://user-images.githubusercontent.com/26313300/58895838-14a26b00-86b2-11e9-8c8c-0d62ff619819.png">
