### PR TITLE
Add optionality for overflow to text boxes

### DIFF
--- a/lib/prawn-fillform.rb
+++ b/lib/prawn-fillform.rb
@@ -313,7 +313,6 @@ module Prawn
           width = options[:width] || field.width
           height = options[:height] || field.height
           overflow = options[:overflow]
-          disable_wrap_by_char = options[:disable_wrap_by_char]
 
           if field.type == :text
             fill_color options[:font_color] || field.font_color
@@ -354,8 +353,7 @@ module Prawn
                 :valign => options[:valign] || :center,
                 :size => size,
                 :style => style,
-                :overflow => overflow,
-                :disable_wrap_by_char => disable_wrap_by_char
+                :overflow => overflow
             end
           elsif field.type == :checkbox
             is_yes = (v = value.downcase) == "yes" || v == "1" || v == "true"

--- a/lib/prawn-fillform.rb
+++ b/lib/prawn-fillform.rb
@@ -312,6 +312,7 @@ module Prawn
           y_position = field.y + y_offset
           width = options[:width] || field.width
           height = options[:height] || field.height
+          overflow = options[:overflow]
 
           if field.type == :text
             fill_color options[:font_color] || field.font_color
@@ -342,7 +343,7 @@ module Prawn
                   :valign => options[:valign] || :center,
                   :size => size,
                   :style => style,
-                  :overflow => :strink_to_fit
+                  :overflow => :shrink_to_fit
               end
             else
               text_box value, :at => [x_position, y_position],
@@ -351,7 +352,8 @@ module Prawn
                 :height => height,
                 :valign => options[:valign] || :center,
                 :size => size,
-                :style => style
+                :style => style,
+                :overflow => overflow
             end
           elsif field.type == :checkbox
             is_yes = (v = value.downcase) == "yes" || v == "1" || v == "true"

--- a/lib/prawn-fillform.rb
+++ b/lib/prawn-fillform.rb
@@ -313,6 +313,7 @@ module Prawn
           width = options[:width] || field.width
           height = options[:height] || field.height
           overflow = options[:overflow]
+          disable_wrap_by_char = options[:disable_wrap_by_char]
 
           if field.type == :text
             fill_color options[:font_color] || field.font_color
@@ -353,7 +354,8 @@ module Prawn
                 :valign => options[:valign] || :center,
                 :size => size,
                 :style => style,
-                :overflow => overflow
+                :overflow => overflow,
+                :disable_wrap_by_char => disable_wrap_by_char
             end
           elsif field.type == :checkbox
             is_yes = (v = value.downcase) == "yes" || v == "1" || v == "true"

--- a/lib/prawn-fillform/version.rb
+++ b/lib/prawn-fillform/version.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 module Prawn
   module Fillform
-    VERSION = "0.1.2.zp"
+    VERSION = "0.1.3.zp"
   end
 end


### PR DESCRIPTION
PrawnPDF text boxes have an `overflow` option that we currently can't set via `prawn-fillform` because we don't check for it. 🤷

The lack of control over `overflow` is particularly problematic because it defaults to `truncate`. We have some tax forms (W2's specifically) that are not showing an employee's full legal name because it gets truncated, which drives touchpoints for Care.

This PR allows consumers of this gem, like Penguin, to set this option as necessary 🎉 